### PR TITLE
Database creation must be execute before the site generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ You should also make sure you have [nodejs][3], Sass, Bower and Grunt installed.
 First of, generate the bundle for your website.
 
     app/console kuma:generate:bundle
+    
+And create the database and fill it using the fixtures
+
+    app/console doctrine:schema:create
+    app/console doctrine:fixtures:load
 
 Next up, generate the default website setup.
 
@@ -68,10 +73,6 @@ Now that all your code is generated, let's make sure all frontend assets are ava
     app/console assets:install
     app/console assetic:dump
 
-And create the database and fill it using the fixtures
-
-    app/console doctrine:schema:create
-    app/console doctrine:fixtures:load
 
 4) Browsing the CMS administration pages
 ----------------------------------------


### PR DESCRIPTION
When the site is generated the follow message is displayed:

Make sure you update your database first before using the created entities:
    Directly update your database:          app/console doctrine:schema:update --force
    Create a Doctrine migration and run it: app/console doctrine:migrations:diff && app/console doctrine:migrations:migrate
    New DataFixtures were created. You can load them via: app/console doctrine:fixtures:load --append

So it assume that the database is already been created.
