### PR TITLE
added strict validation

### DIFF
--- a/app/config/config_base.yml
+++ b/app/config/config_base.yml
@@ -11,7 +11,9 @@ framework:
         strict_requirements: ~
     form:            ~
     csrf_protection: ~
-    validation:      { enable_annotations: true }
+    validation:
+        enable_annotations: true
+        strict_email: true
     templating:
         engines: ['twig']
         #assets_version: SomeVersionScheme

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "doctrine/doctrine-migrations-bundle": "2.1.*@dev",
         "doctrine/migrations": "~1.0@dev",
         "stof/doctrine-extensions-bundle": "1.1.*@dev",
-        "friendsofsymfony/user-bundle": "2.0.*@dev"
+        "friendsofsymfony/user-bundle": "2.0.*@dev",
+        "egulias/email-validator": "~1.2"
     },
     "require-dev": {
         "behat/behat": "~2.5.0",


### PR DESCRIPTION
default email validator is as of sf2.5 non-strict and allows invalid mail addresses.