### PR TITLE
[SeoBundle] Robots.txt management needs extra routes

### DIFF
--- a/app/config/routing.singlelang.yml
+++ b/app/config/routing.singlelang.yml
@@ -51,3 +51,13 @@ KunstmaanUserManagementBundle:
 KunstmaanDashboardBundle:
     resource: "@KunstmaanDashboardBundle/Resources/config/routing.yml"
     prefix:   /
+
+# KunstmaanSeoBundle
+KunstmaanSeoBundle:
+    resource: "@KunstmaanSeoBundle/Resources/config/routing.yml"
+    prefix:   /
+
+# Robots.txt
+KunstmaanSeoBundle_robots:
+    resource: "@KunstmaanSeoBundle/Controller/RobotsController.php"
+    type:     annotation

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -71,3 +71,15 @@ KunstmaanDashboardBundle:
     prefix:   /{_locale}/
     requirements:
         _locale: %requiredlocales%
+
+# KunstmaanSeoBundle
+KunstmaanSeoBundle:
+    resource: "@KunstmaanSeoBundle/Resources/config/routing.yml"
+    prefix:   /{_locale}/
+    requirements:
+	_locale: %requiredlocales%
+
+# Robots.txt
+KunstmaanSeoBundle_robots:
+    resource: "@KunstmaanSeoBundle/Controller/RobotsController.php"
+    type:     annotation


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #302, #283

Adding the robots.txt management in the bundlesCMS needed some extra routes.
They will be added for future project in this PR.