### PR TITLE
[Install] Fix circular dependency problem on routing.yml > routing_dev.yml > routing.yml

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -77,7 +77,7 @@ KunstmaanSeoBundle:
     resource: "@KunstmaanSeoBundle/Resources/config/routing.yml"
     prefix:   /{_locale}/
     requirements:
-	_locale: %requiredlocales%
+        _locale: %requiredlocales%
 
 # Robots.txt
 KunstmaanSeoBundle_robots:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This strange error is the result of using tabs instead of spaces in routing.yml