### PR TITLE
Creates parameters configuration: assetic.node.bin, assetic.uglifyjs.bin and assetic.uglifycss.bin

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -20,15 +20,15 @@ twig:
         #titlebgcolor: "#2997CE"
 
 assetic:
-    node: /usr/bin/node
+    node: "%assetic.node.bin%"
     filters:
         cssrewrite: ~
         scss: ~
         uglifyjs2:
-            bin: /usr/bin/uglifyjs
+            bin: "%assetic.uglifyjs.bin%"
             compress: true
         uglifycss:
-            bin: /usr/bin/uglifycss
+            bin: "%assetic.uglifycss.bin%"
         yui_js:
             jar: %kernel.root_dir%/Resources/tools/java/yuicompressor-2.4.8.jar
         jpegoptim:

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -31,13 +31,13 @@ monolog:
 
 assetic:
     use_controller: "%use_assetic_controller%"
-    node: /usr/local/bin/node
+    node: "%assetic.node.bin%"
     filters:
         uglifyjs2:
-            bin: /usr/local/bin/uglifyjs
+            bin: "%assetic.uglifyjs.bin%"
             compress: true
         uglifycss:
-            bin: /usr/local/bin/uglifycss
+            bin: "%assetic.uglifycss.bin%"
 
 #swiftmailer:
 #    delivery_address: me@example.com

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -17,10 +17,10 @@ swiftmailer:
 
 assetic:
     use_controller: "%use_assetic_controller%"
-    node: node
+    node: "%assetic.node.bin%"
     filters:
         uglifyjs2:
-            bin: node_modules/uglify-js/bin/uglifyjs
+            bin: "%assetic.uglifyjs.bin%"
             compress: true
         uglifycss:
-            bin: node_modules/uglifycss/uglifycss
+            bin: "%assetic.uglifycss.bin%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -42,3 +42,7 @@ parameters:
     google.api.dev_key:         ~
 
     doctrine.server_version:    5.6
+
+    assetic.node.bin: /usr/local/bin/node
+    assetic.uglifyjs.bin: /usr/local/bin/uglifyjs
+    assetic.uglifycss.bin: /usr/local/bin/uglifycss


### PR DESCRIPTION
This refactor is necessary because Ubuntu install those libraries in
/usr/bin/{name}
instead of
/usr/local/bin/{name}

Putting these configuration parameters in the parameters.yml allow each developer to specificy where his OS searches each library.