### PR TITLE
phpunit 4.4 to be able to run the kuma bundles tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "behat/mink-selenium2-driver": "*",
         "behat/mink-goutte-driver": "*",
         "behat/mink-sahi-driver": "*",
-        "phpunit/phpunit": "~3.7",
+        "phpunit/phpunit": "~4.4",
         "fzaninotto/faker": "~1.4.0"
     },
     "scripts": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Update phpunit to the same version as the bundles use. That way the bundle's unit tests could be run without much fuss.