### PR TITLE
locked Symfony on 2.6.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "symfony/symfony": "~2.3",
+        "symfony/symfony": "~2.3,<2.7.0",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
         "twig/extensions": "~1.0",


### PR DESCRIPTION
Symfony 2.7 gives deprecated errors and also a circular reference error.
We need to fix this before we are able to allow Symfony 2.7.