### PR TITLE
Add placeholder for generated password

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -147,6 +147,7 @@ kunstmaan_translator:
     managed_locales: ['nl', 'en', 'de', 'fr']
 
 kunstmaan_admin:
+    admin_password: -adminpwd-
     dashboard_route: 'kunstmaan_dashboard'
 
 ekino_new_relic:


### PR DESCRIPTION
Before generating the default admin user, a placeholder for the generated password should be added to the app/resources/config.yml file.

The admin user is generated by running: app/console doctrine:fixtures:load. The new password will be displayed on the console to the user and the -adminpwd- placeholder will be replaced by the generated password.