### PR TITLE
Move to psr-4 as psr-0 is deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "description": "The \"Kunstmaan Bundles CMS Standard Edition\" distribution",
     "autoload": {
-        "psr-0": { "": "src/", "SymfonyStandard": "app/" }
+        "psr-4": { "": "src/", "SymfonyStandard\\": "app/" }
     },
     "require": {
         "php": ">=5.4.0",


### PR DESCRIPTION
The standard edition should use the current standards, and move to PSR-4 (cfr. http://www.php-fig.org/psr/psr-0/).