### PR TITLE
Update app.php ApcClassLoader code and comment to match Symfony >2.5

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -6,11 +6,12 @@ use Symfony\Component\Debug\Debug;
 
 $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
 
-if(extension_loaded('apc') && ini_get('apc.enabled')){
-    // Use APC for autoloading to improve performance.
-    // Change 'sf2' to a unique prefix in order to prevent cache key conflicts with other applications also using APC.
-    // The Kunstmaan build system does this automatically.
-    $apcLoader = new ApcClassLoader('sf2', $loader);
+if (extension_loaded('apc') && ini_get('apc.enabled')) {
+    // Enable APC for autoloading to improve performance.
+    // You should change the ApcClassLoader first argument to a unique prefix
+    // in order to prevent cache key conflicts with other applications
+    // also using APC.
+    $apcLoader = new ApcClassLoader(sha1(__FILE__), $loader);
     $loader->unregister();
     $apcLoader->register(true);
 }


### PR DESCRIPTION
Because the ApcClassLoader code in `web/app.php` is enabled by default in Kunstmaan's 'StandardEdition' (when APC is available) I would suggest to update those lines to match Symfony 2.5-2.7's 'StandardEdition'.

```php
$apcLoader = new ApcClassLoader(sha1(__FILE__), $loader);
// ^ new vs old v
$apcLoader = new ApcClassLoader('sf2', $loader);
```

We are running some test apps on the same VM, with shared PHP instance (mod_php) and this caused quite some trouble and head-scratching.

Since we know this `sf2` perfix was the issue, we've updated those strings to be unique, but I think using the `sha1(__FILE__)` would be a safer default.

This change was introduced in Symfony's StandardEdition v2.5 and is there since.