### PR TITLE
PSR-4 path to `SymfonyStandard` is incorrect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "description": "The \"Kunstmaan Bundles CMS Standard Edition\" distribution",
     "autoload": {
-        "psr-4": { "": "src/", "SymfonyStandard\\": "app/" }
+        "psr-4": { "": "src/", "SymfonyStandard\\": "app/SymfonyStandard/" }
     },
     "require": {
         "php": ">=5.4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a

PSR-4 path to `SymfonyStandard` is incorrect

It was simply replaced at b38fd73b1cb38c9bdf6e50aa3a2996d0e43a4f9a `psr-0` with `psr-4` but it additionally requires fixing the path to the namespace.