### PR TITLE
Add gedmo.listener.tree definition to config.yml

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -140,6 +140,13 @@ services:
     kunstmaan_newrelic_naming_strategy:
         class: Kunstmaan\UtilitiesBundle\Helper\UrlTransactionNamingStrategy
 
+    gedmo.listener.tree:
+        class: Gedmo\Tree\TreeListener
+        tags:
+            - { name: doctrine.event_subscriber, connection: default }
+        calls:
+            - [ setAnnotationReader, [ @annotation_reader ] ]
+
 white_october_pagerfanta:
     default_view: twitter_bootstrap
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | none

`gedmo.listener.tree` was removed from NodeBudle in https://github.com/Kunstmaan/KunstmaanBundlesCMS/pull/846 and needs to by defined in application config.