### PR TITLE
[Config] Added filters for srcset in ImagePagePart to config

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -113,6 +113,58 @@ liip_imagine:
             filters:
                 strip: ~
 
+        # ImagePagePart srcset JPG filters
+        image_huge_jpg:
+            quality: 95
+            format: jpg
+            filters:
+                strip: ~
+                thumbnail: { size: [2400,null], mode: outbound, allow_upscale: false }
+        image_big_jpg:
+            quality: 95
+            format: jpg
+            filters:
+                strip: ~
+                thumbnail: { size: [1200,null], mode: outbound, allow_upscale: false }
+        image_medium_jpg:
+            quality: 95
+            format: jpg
+            filters:
+                strip: ~
+                thumbnail: { size: [600,null], mode: outbound, allow_upscale: false }
+        image_small_jpg:
+            quality: 95
+            format: jpg
+            filters:
+                strip: ~
+                thumbnail: { size: [400,null], mode: outbound, allow_upscale: false }
+
+        # ImagePagePart srcset PNG filters
+        image_huge_png:
+            quality: 95
+            format: png
+            filters:
+                strip: ~
+                thumbnail: { size: [2400,null], mode: outbound, allow_upscale: false }
+        image_big_png:
+            quality: 95
+            format: png
+            filters:
+                strip: ~
+                thumbnail: { size: [1200,null], mode: outbound, allow_upscale: false }
+        image_medium_png:
+            quality: 95
+            format: png
+            filters:
+                strip: ~
+                thumbnail: { size: [600,null], mode: outbound, allow_upscale: false }
+        image_small_png:
+            quality: 95
+            format: png
+            filters:
+                strip: ~
+                thumbnail: { size: [400,null], mode: outbound, allow_upscale: false }
+                
 services:
     twig.extension.text:
         class: Twig_Extensions_Extension_Text


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

These image filters need to be present in the config file for srcset in ImagePagePart to work.
The template will crash if filters are not found.