### PR TITLE
Set cookie_httponly to false

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -8,6 +8,8 @@ framework:
     translator:         { fallback: %locale% }
     session:
         name:               %session_prefix%
+        # set true if no scripting languages need to access the cookie
+        cookie_httponly:    false
     templating:
         assets_version:     v1
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | 

When moving onwards symfony 2.8, cookie_httponly needs to be set to false. If not, any scripting language like javascript, can not access the cookie variable.

See https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#frameworkbundle