### PR TITLE
Use validator.mapping.cache.doctrine.apc for apc caching

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -3,7 +3,7 @@ imports:
 
 framework:
     validation:
-        cache: apc
+        cache: validator.mapping.cache.doctrine.apc
 
 doctrine:
     orm:

--- a/app/config/config_staging.yml
+++ b/app/config/config_staging.yml
@@ -3,7 +3,7 @@ imports:
 
 framework:
     validation:
-        cache: apc
+        cache: validator.mapping.cache.doctrine.apc
 
 doctrine:
     orm:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | 

The ability to pass apc as the framework.validation.cache configuration key value is deprecated, and will be removed in 3.0. Use validator.mapping.cache.doctrine.apc instead

See https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#frameworkbundle