### PR TITLE
Update LiipImagineBundle to v1.4.3 (fix)

### DIFF
--- a/app/config/routing.singlelang.yml
+++ b/app/config/routing.singlelang.yml
@@ -1,7 +1,6 @@
 # KunstmaanMediaBundle
-_imagine:
-    resource: .
-    type:     imagine
+_liip_imagine:
+    resource: "@LiipImagineBundle/Resources/config/routing.xml"
 
 KunstmaanMediaBundle:
     resource: "@KunstmaanMediaBundle/Resources/config/routing.yml"


### PR DESCRIPTION
Fix the https://github.com/Kunstmaan/KunstmaanBundlesStandardEdition/commit/7949dbf2dbc83c5d3d1a90fde880f9076552076a commit.