### PR TITLE
Default maintenance template page

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -19,6 +19,21 @@ DirectoryIndex app.php
 
 <IfModule mod_rewrite.c>
     RewriteEngine On
+    
+    # Enable maintenance: copy maintenance_template.html to maintenance.html
+    #
+    # never maintenance for admin
+    RewriteRule ^[^/]+/admin.* %{ENV:BASE}/app.php [L,END]
+    RewriteRule ^admin.* %{ENV:BASE}/app.php [L,END]
+
+    RewriteCond %{DOCUMENT_ROOT}/maintenance.html -f
+    RewriteCond %{REQUEST_FILENAME} -f [OR]
+    RewriteCond %{REQUEST_FILENAME} -d [OR]
+    RewriteCond %{REQUEST_FILENAME} -l
+    # if you have the nomaintenance cookie you should not see the maintenance page
+    RewriteCond %{HTTP_COOKIE} !^.*nomaintenance.*$ [NC]
+    RewriteCond %{REQUEST_FILENAME} !\.(css|gif|jpg|png|js|woff|jpeg|svg|woff2).*
+    RewriteRule ^ maintenance.html [L]
 
     # Determine the RewriteBase automatically and set it as environment variable.
     # If you are using Apache aliases to do mass virtual hosting or installed the

--- a/web/maintenance_template.html
+++ b/web/maintenance_template.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<!--[if lte IE 9]> <html class="no-js lte-ie9"> <![endif]-->
+<!--[if gt IE 9]><!--> <html> <!--<![endif]-->
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, follow">
+
+    <title>Maintenance</title>
+
+    <link rel="icon" href="/favicon.ico" type="image/x-icon"/>
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon"/>
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
+    <link rel="stylesheet" href="/frontend/css/style.min.css" type="text/css" />
+
+</head>
+<body class="splash splash--maintenance">
+<div class="off-canvas__wrapper  .text-center">
+    <div class="splash__container" style="text-align: center">
+
+        <header class="row">
+            <div class="col-sm-12">
+                <img id="js-maintenance" class="splash__header__logo" src="/apple-touch-icon.png" alt="Logo">
+            </div>
+        </header>
+        <div class="row splash__content" >
+            <div class="col-sm-12 splash__content__section">
+                <h1 class="splash__content__title">
+                    Maintenance
+                </h1>
+                <div class="splash__content__links">
+                    <p>
+                        We are currently in maintenance
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</div>
+<!-- maintenance-inject:js -->
+<script >
+
+var Maintenance = Maintenance || {};
+
+Maintenance = (function(window, undefined) {
+
+    var init, clickHandler, setCookie,
+        clicks = 0,
+        minClicks = 8,
+        logo,
+        cookie = {
+            name: 'nomaintenance',
+            value: 'true',
+            expires: 30 //minutes
+        };
+
+    clickHandler = function() {
+        clicks++;
+
+        if (clicks >= minClicks) {
+            logo.removeEventListener('click', clickHandler, false);
+            setCookie();
+            window.location.reload();
+        }
+    };
+
+    setCookie = function() {
+        var date = new Date(new Date().getTime() + (cookie.expires * 60 * 1000)),
+            expires = ';expires="' + date.toGMTString() + '"';
+
+        document.cookie = cookie.name + '=' + cookie.value + expires + ';path=/';
+    };
+
+    init = function() {
+        logo = document.getElementById('js-maintenance');
+        logo.addEventListener('click', clickHandler, false);
+    };
+
+    return {
+        init: init
+    };
+
+})(window);
+
+document.addEventListener('DOMContentLoaded', function() {
+    Maintenance.init();
+});
+</script>
+<!-- endinject -->
+</body>
+</html>
+
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no

With the feature you can easily enable maintenance mode by copying maintenance_template.html to maintenance.html. Disabling is by removing the file.
When clicking 8 times on the logo the maintenance mode is ignored for 30 minutes.
Also the backend and preview will not be in maintenance.
This behaviour can easily be changed in the .htaccess

Be aware this will offcourse only work on an apache setup.
