### PR TITLE
elastic host and port in parameters.yml.dist

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -29,7 +29,8 @@ parameters:
     websitetitle:               MyProject
     session_prefix:             myproject
 
-    searchport:                 9200
+    kunstmaan_search.hostname:  localhost
+    kunstmaan_search.port:      9200
     searchindexname:            myproject
     searchindexprefix:          myproject
 


### PR DESCRIPTION
The current entry in parameters.yml (searchport) is not used anywhere in the code. Instead, the two new entries override the corresponding settings in the services.yml in SearchBundle.
