### PR TITLE
[AdminListBundle] new routing defined

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -15,6 +15,13 @@ KunstmaanAdminBundle:
     requirements:
         _locale: "%requiredlocales%"
 
+# KunstmaanAdminListBundle
+KunstmaanAdminListBundle:
+    resource: "@KunstmaanAdminListBundle/Resources/config/routing.yml"
+    prefix:   /{_locale}/
+    requirements:
+        _locale: "%requiredlocales%"
+
 # KunstmaanNodeBundle
 KunstmaanNodeBundle:
     resource: "@KunstmaanNodeBundle/Resources/config/routing.yml"


### PR DESCRIPTION
If "locking for entities"[Kunstmaan/KunstmaanBundlesCMS#1384] is merged in kunstmaanbundles, AdminListBundle now has a controller with an action and its routing.yml needs to be referenced