### PR TITLE
[Composer]: add fos-user beta to standard edition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "friendsofsymfony/http-cache-bundle": "~1.3.6",
         "ekino/newrelic-bundle": "~1.3.2",
         "doctrine/doctrine-migrations-bundle": "~1.1.1",
+        "friendsofsymfony/user-bundle": "2.0.0-beta1",
         "sentry/sentry": "^1.4"
     },
     "require-dev": {


### PR DESCRIPTION
Needed because when adding it only to the KunstmaanBundlesCms it will not be installed because of our minimum stability requirement.