### PR TITLE
Removed double gedmo treelistener service from config

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -195,13 +195,6 @@ services:
     kunstmaan_newrelic_naming_strategy:
         class: Kunstmaan\UtilitiesBundle\Helper\UrlTransactionNamingStrategy
 
-    gedmo.listener.tree:
-        class: Gedmo\Tree\TreeListener
-        tags:
-            - { name: doctrine.event_subscriber, connection: default }
-        calls:
-            - [ setAnnotationReader, [ "@annotation_reader" ] ]
-
     fos_user.doctrine_registry:
         alias: doctrine
 


### PR DESCRIPTION
The gedmo treelistener service is already added by stof, no need to add it twice. It's the source of a range of bugs that it's defined twice.