### PR TITLE
[Config] add parameter to change liip imagine data root

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -67,3 +67,9 @@ fos_http_cache:
                         max_age: 360
                         s_maxage: 360
                     vary: [Cookie, Accept-Encoding, Accept-Language]
+
+liip_imagine:
+  loaders:
+    default:
+      filesystem:
+        data_root: "%liip_imagine_filesystem_data_root%"

--- a/app/config/config_staging.yml
+++ b/app/config/config_staging.yml
@@ -66,3 +66,9 @@ fos_http_cache:
                         max_age: 360
                         s_maxage: 360
                     vary: [Cookie, Accept-Encoding, Accept-Language]
+
+liip_imagine:
+  loaders:
+    default:
+      filesystem:
+        data_root: "%liip_imagine_filesystem_data_root%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,44 +1,34 @@
-parameters:
-    database_driver:            pdo_mysql
-    database_host:              127.0.0.1
-    database_port:              ~
-    database_name:              kunstmaanbundles
-    database_user:              travis
-    database_password:          ~
-
-    mailer_transport:           smtp
-    mailer_host:                127.0.0.1
-    mailer_user:                ~
-    mailer_password:            ~
-
-    locale:                     en
-    secret:                     ThisTokenIsNotSoSecretChangeIt
-
-    debug_toolbar:              true
-    debug_redirects:            false
-    use_assetic_controller:     true
-
-    requiredlocales:            nl|fr|de|en
-    defaultlocale:              en
-    multilanguage:              true
-
-    sentry.dsn:                 https://XXXXXXXX:XXXXXXXX@app.getsentry.com/XXXX
-
-    cdnpath:                    ~
-
-    websitetitle:               MyProject
-    session_prefix:             myproject
-
-    searchport:                 9200
-    searchindexname:            myproject
-    searchindexprefix:          myproject
-
-    analytics.googletagmanager: GTM-XXXXXX
-
-    aviary_api_key:             Register on https://creativesdk.adobe.com/myapps.html
-
-    google.api.client_id:       More info at http://bundles.kunstmaan.be/documentation/cookbook/google-analytics-dashboard
-    google.api.client_secret:   ~
-    google.api.dev_key:         ~
-
-    doctrine.server_version:    5.6
+parameters: 
+  analytics.googletagmanager: GTM-XXXXXX
+  aviary_api_key: "Register on https://creativesdk.adobe.com/myapps.html"
+  cdnpath: ~
+  database_driver: pdo_mysql
+  database_host: "127.0.0.1"
+  database_name: kunstmaanbundles
+  database_password: ~
+  database_port: ~
+  database_user: travis
+  debug_redirects: false
+  debug_toolbar: true
+  defaultlocale: en
+  doctrine.server_version: 5.6
+  google.api.client_id: "More info at http://bundles.kunstmaan.be/documentation/cookbook/google-analytics-dashboard"
+  google.api.client_secret: ~
+  google.api.dev_key: ~
+  liip_imagine_filesystem_data_root: 
+    - "%kernel.root_dir%/../web"
+  locale: en
+  mailer_host: "127.0.0.1"
+  mailer_password: ~
+  mailer_transport: smtp
+  mailer_user: ~
+  multilanguage: true
+  requiredlocales: nl|fr|de|en
+  searchindexname: myproject
+  searchindexprefix: myproject
+  searchport: 9200
+  secret: ThisTokenIsNotSoSecretChangeIt
+  sentry.dsn: "https://XXXXXXXX:XXXXXXXX@app.getsentry.com/XXXX"
+  session_prefix: myproject
+  use_assetic_controller: true
+  websitetitle: MyProject


### PR DESCRIPTION
The upgrade of the liip imagine bundle can not resolve cache paths with symbolic links. Therefore it's a good case to add the filesystem data_root parameter of liip_imagine as a parameter. When installing the standard edition, this parameter will be requested. If you run your website without the use of a symbolic link to the web directory, there will be no problem. 