### PR TITLE
SetTrustedProxies requires second argument

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -37,7 +37,7 @@ if (getenv('APP_ENV') !== 'dev' && getenv('APP_ENV') !== 'docker') {
 }
 
 Request::enableHttpMethodParameterOverride();
-Request::setTrustedProxies(array('127.0.0.1'));
+Request::setTrustedProxies(['127.0.0.1'], Request::HEADER_X_FORWARDED_ALL);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
User Deprecated: The Symfony\Component\HttpFoundation\Request::setTrustedProxies() method expects a bit field of Request::HEADER_* as second argument since version 3.3. Defining it will be required in 4.0. 