### PR TITLE
[Config] added fos user required email parameters

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -226,3 +226,8 @@ ekino_new_relic:
     log_commands:   true
     transaction_naming: service
     transaction_naming_service: kunstmaan_newrelic_naming_strategy
+
+fos_user:
+    from_email:
+        address: "%mailer_from_address%"
+        sender_name: "%mailer_from_name%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -18,6 +18,8 @@ parameters:
   liip_imagine_filesystem_data_root: 
     - "%kernel.root_dir%/../web"
   locale: en
+  mailer_from_address: "info@myproject.dev"
+  mailer_from_name: "Kunstmaan CMS"
   mailer_host: "127.0.0.1"
   mailer_password: ~
   mailer_transport: smtp


### PR DESCRIPTION
With the updated version of FOS UserBundle there is extra config required. https://symfony.com/doc/master/bundles/FOSUserBundle/index.html#step-5-configure-the-fosuserbundle