### PR TITLE
[Travis] Refactor travis build config and implement extra features/checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,11 @@
 language: php
 
-sudo: true
-
-addons:
-  chrome: stable
-  apt:
-    packages:
-    - libxss1
-    - imagemagick
-    - ghostscript
+sudo: false
 
 cache:
   directories:
     - $HOME/.composer/cache
+    - node_modules
     - vendor
     - $BUILD_CACHE_DIR
 
@@ -20,17 +13,14 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 matrix:
   fast_finish: true
 
 services:
   - elasticsearch
-
-mysql:
-  database: kunstmaanbundles
-  username: travis
-  encoding: utf8
+  - mysql
 
 env:
   global:
@@ -39,60 +29,16 @@ env:
     - TRAVIS_BUILD_DIR=.travis/build
 
 before_install:
-  - composer selfupdate
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+  - .travis/before_install.sh
 
 install:
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo "" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi;'
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ] && [ $(php -r "echo PHP_MINOR_VERSION;") -le 4 ] && [ $(php -r "echo PHP_MAJOR_VERSION;") -le 5 ]; then echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "~ 5.[56]" ] ; then echo yes | pecl install apcu-4.0.10; fi;'
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "7.*" ] ; then pecl config-set preferred_state beta; echo yes | pecl install apcu; echo "extension = apcu.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ] && [ $(php -r "echo PHP_MAJOR_VERSION;") -le 5 ]; then echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ] && [ $(php -r "echo PHP_MAJOR_VERSION;") -le 5 ]; then echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;'
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "< 7.[1]" ]; then printf "\n" | pecl install imagick-3.4.0RC6; fi;'
-  - chmod -R 777 var/cache/ var/logs/
-
+  - .travis/install.sh
 
 before_script:
-  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS kunstmaanbundles;'; fi"
-  - cp app/config/parameters.yml.dist app/config/parameters.yml
-  - sh -c "if [ '$DB' = 'mysql' ]; then sed -i 's/dbuser/travis/g' app/config/parameters.yml; fi"
-  - composer install --no-scripts
-  - composer dump-autoload --optimize
-  - php vendor/sensio/distribution-bundle/Resources/bin/build_bootstrap.php
-  - bin/console --force --no-interaction doctrine:schema:drop --env=dev
-  - bin/console --no-interaction doctrine:schema:create --env=dev
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sleep 3
-  - wget http://selenium-release.storage.googleapis.com/3.9/selenium-server-standalone-3.9.1.jar
-  - wget https://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip
-  - unzip chromedriver_linux64.zip
-  - sudo cp ./chromedriver /usr/bin/
-  - sudo chmod ugo+rx /usr/bin/chromedriver
-  - java -jar selenium-server-standalone-3.9.1.jar > /dev/null 2>&1 &
-  - sleep 5
+  - .travis/before_script.sh
 
 script:
-  - bin/console kuma:generate:bundle --namespace="MyProject\\WebsiteBundle" --no-interaction --dir=src
-  - bin/console kuma:generate:default-site --namespace="MyProject\\WebsiteBundle" --prefix="myproject_" --demosite --browsersync=kunstmaanbundlescms.dev --articleoverviewpageparent="HomePage,ContentPage" --no-interaction
-  - nvm install
-  - npm set progress=false
-  - npm install
-  - npm run build
-  - bin/console --force --no-interaction doctrine:schema:drop --env=dev
-  - bin/console --no-interaction doctrine:schema:create --env=dev
-  - bin/console --no-interaction doctrine:fixtures:load --env=dev
-  - bin/console kuma:generate:admin-tests --namespace="MyProject\\WebsiteBundle"
-  - bin/console --no-interaction assets:install --env=test
-  - bin/console --no-interaction cache:clear --env=test
-  - bin/console --no-interaction cache:warmup --env=test
-  - chmod -R 777 var/cache/ var/logs/
-  - bin/console server:start
-  - phpunit
-  - php -d memory_limit=2048M bin/behat --suite=default --verbose
-  - bin/console server:stop
+  - .travis/script.sh
 
 after_failure:
   - .travis/after_failure.sh

--- a/.travis/after_failure.sh
+++ b/.travis/after_failure.sh
@@ -1,8 +1,22 @@
 #!/usr/bin/env bash
 
-vendor/bin/upload-textfiles "${TRAVIS_BUILD_DIR}/*.log"
+echo "Upload log files..."
 
-echo "Uploading behat failed step screenshots..."
+# Copy application logs to the build dir
+cp var/logs/test.log ${TRAVIS_BUILD_DIR}
+
+for file in ${TRAVIS_BUILD_DIR}/*.log
+do
+    if [ ! -e "$file" ]
+    then
+        break
+    fi
+
+    url=`cat "$file" | nc termbin.com 9999`
+    echo "$file - $url"
+done
+
+echo "Upload behat failed step screenshots..."
 
 # Please generate a client key for yourself and don't use ours to avoid reaching the rate limit.
 clientid='6747e004f45c83a'

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Disable XDebug
+phpenv config-rm xdebug.ini || exit $?
+# Create build cache directory
+mkdir -p \"${BUILD_CACHE_DIR}\" || exit $?
+
+composer self-update --stable || exit $?

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+mysql -e 'create database IF NOT EXISTS kunstmaanbundles;'
+cp app/config/parameters.yml.dist app/config/parameters.yml
+sed -i 's/dbuser/travis/g' app/config/parameters.yml
+composer install --no-scripts --optimize-autoloader || exit $?
+bin/console --force --no-interaction doctrine:schema:drop --env=dev || exit $?
+bin/console --no-interaction doctrine:schema:create --env=dev || exit $?
+
+if [[ $TRAVIS_PHP_VERSION = 5.* ]]; then
+    php vendor/sensio/distribution-bundle/Resources/bin/build_bootstrap.php
+fi
+
+echo "Prepare behat environment"
+
+# Configure display
+/sbin/start-stop-daemon --start --quiet --pidfile /tmp/xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1680x1050x16
+export DISPLAY=:99
+
+chromium-browser --version
+
+# Download and configure ChromeDriver
+if [ ! -f $BUILD_CACHE_DIR/chromedriver ] || [ "$($BUILD_CACHE_DIR/chromedriver --version | grep -c 2.35)" = "0" ]; then
+    # Using ChromeDriver 2.35 which supports Chrome 62-64, we're using Chromium 62
+    curl https://chromedriver.storage.googleapis.com/2.35/chromedriver_linux64.zip > chromedriver.zip
+    unzip chromedriver.zip
+    mv chromedriver $BUILD_CACHE_DIR
+fi
+
+# Download and configure Selenium
+if [ ! -f $BUILD_CACHE_DIR/selenium.jar ] || [ "$(java -jar $BUILD_CACHE_DIR/selenium.jar --version | grep -c 3.11.0)" = "0" ]; then
+    curl https://selenium-release.storage.googleapis.com/3.11/selenium-server-standalone-3.11.0.jar > selenium.jar
+    mv selenium.jar $BUILD_CACHE_DIR
+fi
+
+echo "Start selenium"
+PATH=$PATH:$BUILD_CACHE_DIR java -jar $BUILD_CACHE_DIR/selenium.jar > $TRAVIS_BUILD_DIR/selenium.log 2>&1 &
+sleep 5

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# No memory limit for running the behat tests
+echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
+echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+# Enable additional PHP extensions
+if [[ $TRAVIS_PHP_VERSION =~ 7.[01] ]]; then
+    echo "install php 7 apc package"
+    pecl config-set preferred_state beta; echo yes | pecl install apcu || exit $?;
+fi
+
+echo "extension = apcu.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/php.ini;
+
+chmod -R 777 var/cache/ var/logs/

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+bin/console kuma:generate:bundle --namespace="MyProject\\WebsiteBundle" --dir=src --no-interaction || exit $?
+bin/console kuma:generate:default-site --namespace="MyProject\\WebsiteBundle" --prefix="myproject_" --demosite --browsersync=kunstmaanbundlescms.dev --articleoverviewpageparent="HomePage,ContentPage" --no-interaction || exit $?
+
+# Setup frontend
+npm set progress=false
+npm --version
+npm install
+npm run build
+
+# Setup application
+bin/console doctrine:schema:drop --env=dev --force --no-interaction || exit $?
+bin/console doctrine:schema:create --env=dev --no-interaction || exit $?
+bin/console doctrine:fixtures:load --env=dev --no-interaction || exit $?
+bin/console kuma:generate:admin-tests --namespace="MyProject\\WebsiteBundle" || exit $?
+bin/console assets:install --env=test --no-interaction || exit $?
+bin/console cache:clear --env=test --no-interaction || exit $?
+bin/console cache:warmup --env=test --no-interaction || exit $?
+chmod -R 777 var/cache/ var/logs/
+
+# Check that the YAML config files contain no syntax errors
+bin/console lint:yaml app/config || exit $?
+# Check that the Twig template files contain no syntax errors
+bin/console lint:twig app/Resources/views || exit $?
+bin/console lint:twig src/MyProject/WebsiteBundle/Resources/views || exit $?
+# Check that the application doesn't use dependencies with known security vulnerabilities
+bin/console security:check --end-point=http://security.sensiolabs.org/check_lock || exit $?
+
+# Start webserver for behat
+bin/console server:run 127.0.0.1:8000 --no-debug --quiet > $TRAVIS_BUILD_DIR/webserver.log 2>&1 &
+
+# Run behat tests
+php -d memory_limit=2048M bin/behat --suite=default --strict -f progress || exit $?

--- a/behat.yml
+++ b/behat.yml
@@ -11,20 +11,31 @@
 default:
     extensions:
         Behat\Symfony2Extension:
-#          mink_driver: true
           kernel:
             env: test
             debug: true
         Behat\MinkExtension:
             base_url: 'http://localhost:8000/'
-            #javascript_session: sahi
             browser_name: chrome
-            goutte: ~
             selenium2: ~
             files_path: '%paths.base%/src/MyProject/WebsiteBundle/Features/Media/'
+            default_session: chrome
+            sessions:
+                chrome:
+                    selenium2:
+                        browser: chrome
+                        capabilities:
+                            browserName: chrome
+                            browser: chrome
+                            version: ''
+                            chrome:
+                                switches:
+                                    - 'start-fullscreen'
+                                    - 'start-maximized'
+                                    - 'no-sandbox'
 
         Lakion\Behat\MinkDebugExtension:
-            directory: .travis/build
+            directory: '%paths.base%/.travis/build'
             clean_start: false
             screenshot: true
 


### PR DESCRIPTION
This PR finishes my work I started at the kumathon. It's a refactor the travis build config. Overview of all changes:

- Switch to the `sudo: false` aka container based to speedup the startup of the builds
- Setup travis caches to speed up build. With this we cut of +/- 4min of each build (for php5 even more)
- Use the pre-installed chrome to make the build invironment more reliable and predictable.
- Cache the selenium and chrome driver download
- I've added extra check to validate code/twig/security etc
  - Lint the yaml config files in `app/config`
  - Lint the twig files generated during bundle setup
  - Check our composer.lock on the usage of libraries with security vulnerabilities
- On build failure we now also upload the logs files (behat, selenium, application). This in combination with the screenshot upload, will make debugging issues in the behat test suite easier.
- Enabled PHP 7.2

Old build duration:
<img width="961" alt="screen shot 2018-04-30 at 12 20 43 pm" src="https://user-images.githubusercontent.com/1374857/39423499-792c72a8-4c72-11e8-8d2e-5f5f905fba59.png">

New build duration:
<img width="954" alt="screen shot 2018-04-30 at 12 20 36 pm" src="https://user-images.githubusercontent.com/1374857/39423498-79122da8-4c72-11e8-96e6-a6d2badf1136.png">