### PR TITLE
Add sensio distribution bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "friendsofsymfony/http-cache-bundle": "~1.3.6",
         "ekino/newrelic-bundle": "~1.3.2",
         "sentry/sentry": "^1.4",
-        "symfony/swiftmailer-bundle": "^2.6.4"
+        "symfony/swiftmailer-bundle": "^2.6.4",
+        "sensio/distribution-bundle": "^5.0"
     },
     "require-dev": {
         "behat/behat": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b438b138d503c550deeda23b3de4850",
+    "content-hash": "3cb12ed3c39f660c529a93e4d0662534",
     "packages": [
         {
             "name": "behat/transliterator",


### PR DESCRIPTION
I've removed this dependency from the bundles package, but it should be present in the project itself to allow executing the composer post install/update scripts. See Kunstmaan/KunstmaanBundlesCMS#2023