### PR TITLE
Update symfony/symfony to latest version for security patches

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2765,12 +2765,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Kunstmaan/KunstmaanBundlesCMS.git",
-                "reference": "8b955eb6c74c511eacf7afef5417726b179a75a3"
+                "reference": "90652a05065c9c89dbd6deeb02be576ecf0109b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Kunstmaan/KunstmaanBundlesCMS/zipball/8b955eb6c74c511eacf7afef5417726b179a75a3",
-                "reference": "8b955eb6c74c511eacf7afef5417726b179a75a3",
+                "url": "https://api.github.com/repos/Kunstmaan/KunstmaanBundlesCMS/zipball/90652a05065c9c89dbd6deeb02be576ecf0109b6",
+                "reference": "90652a05065c9c89dbd6deeb02be576ecf0109b6",
                 "shasum": ""
             },
             "require": {
@@ -2786,8 +2786,8 @@
                 "doctrine/orm": "^2.5",
                 "egulias/email-validator": "^1.2.8|^2.0",
                 "fpn/doctrine-extensions-taggable": "~0.9",
-                "friendsofsymfony/user-bundle": "2.0.*",
-                "gedmo/doctrine-extensions": "~2.3",
+                "friendsofsymfony/user-bundle": "^2.0",
+                "gedmo/doctrine-extensions": "^2.4.34",
                 "guzzlehttp/guzzle": "~6.1",
                 "imagine/imagine": "~0.6",
                 "incenteev/composer-parameter-handler": "^2.0",
@@ -2797,21 +2797,20 @@
                 "liip/imagine-bundle": "~1.7",
                 "php": ">=5.6.0",
                 "ruflin/elastica": "^5.1|^6.0",
-                "sensio/distribution-bundle": "^5.0",
                 "sensio/framework-extra-bundle": "^5.0",
                 "sensio/generator-bundle": "~3.0",
                 "stof/doctrine-extensions-bundle": "~1.1",
                 "symfony-cmf/routing-bundle": "~2.0",
                 "symfony/monolog-bundle": "~2.8|~3.0",
                 "symfony/security-acl": "~2.8|~3.0",
-                "symfony/swiftmailer-bundle": "^2.3",
+                "symfony/swiftmailer-bundle": "^2.3|^3.0",
                 "symfony/symfony": "~3.4",
                 "twig/extensions": "~1.0",
                 "twig/twig": "^1.12|^2.0",
                 "white-october/pagerfanta-bundle": "~1.0"
             },
             "conflict": {
-                "friendsofsymfony/user-bundle": "<2.0.0, >=2.1.0"
+                "friendsofsymfony/user-bundle": "<2.0.0"
             },
             "replace": {
                 "kunstmaan/admin-bundle": "self.version",
@@ -2885,7 +2884,7 @@
             "keywords": [
                 "cms"
             ],
-            "time": "2018-07-11T13:23:45+00:00"
+            "time": "2018-09-10T07:21:45+00:00"
         },
         {
             "name": "kunstmaan/google-api-custom",
@@ -4787,20 +4786,20 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v3.4.11",
+            "version": "v3.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "8eb567d8398ce31a402ea8db3e6b5b1faf121cbc"
+                "reference": "f50e17fa4edd6216f7fe5b908f04e64ba1d19a9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/8eb567d8398ce31a402ea8db3e6b5b1faf121cbc",
-                "reference": "8eb567d8398ce31a402ea8db3e6b5b1faf121cbc",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/f50e17fa4edd6216f7fe5b908f04e64ba1d19a9e",
+                "reference": "f50e17fa4edd6216f7fe5b908f04e64ba1d19a9e",
                 "shasum": ""
             },
             "require": {
-                "doctrine/common": "~2.4",
+                "doctrine/common": "~2.4@stable",
                 "ext-xml": "*",
                 "fig/link-util": "^1.0",
                 "php": "^5.5.9|>=7.0.8",
@@ -4819,7 +4818,7 @@
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
-                "phpdocumentor/type-resolver": "<0.2.1",
+                "phpdocumentor/type-resolver": "<0.3.0",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
             },
             "provide": {
@@ -4888,7 +4887,7 @@
                 "doctrine/data-fixtures": "1.0.*",
                 "doctrine/dbal": "~2.4",
                 "doctrine/doctrine-bundle": "~1.4",
-                "doctrine/orm": "~2.4,>=2.4.5",
+                "doctrine/orm": "~2.4,>=2.4.5,<=2.7.0",
                 "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
                 "monolog/monolog": "~1.11",
                 "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
@@ -4938,7 +4937,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2018-05-25T13:16:49+00:00"
+            "time": "2018-08-01T14:48:04+00:00"
         },
         {
             "name": "twig/extensions",


### PR DESCRIPTION
Update `symfony/symfony` from `v3.4.11` to `v3.4.14` to get the latest security patches. Travis build will also fail when there are packages with security vulnerabilities.

See [CVE-2018-14773](https://symfony.com/blog/cve-2018-14773-remove-support-for-legacy-and-risky-http-headers) and [CVE-2018-14774](https://symfony.com/blog/cve-2018-14774-possible-host-header-injection-when-using-httpcache)