### PR TITLE
[Config] Use correct routing file for v2 of liip/imagine-bundle

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,6 +1,6 @@
 # KunstmaanMediaBundle
 _liip_imagine:
-    resource: "@LiipImagineBundle/Resources/config/routing.xml"
+    resource: "@LiipImagineBundle/Resources/config/routing.yaml"
 
 KunstmaanMediaBundle:
     resource: "@KunstmaanMediaBundle/Resources/config/routing.yml"


### PR DESCRIPTION
In liip/imagine-bundle v2 the `routing.xml` file is remove and `routing.yaml` is the only file to be included (previously the xml file included the yaml file)

Follow up PR for Kunstmaan/KunstmaanBundlesCMS#2098